### PR TITLE
pass tenant ID to msal

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,3 +3,4 @@ ClientSecret = "TxRBilcHdC6WGBee]fs?QR:SJ8nI[g82"
 Scopes = ['https://outlook.office.com/IMAP.AccessAsUser.All','https://outlook.office.com/SMTP.Send']
 RefreshTokenFileName = "imap_smtp_refresh_token"
 AccessTokenFileName = "imap_smtp_access_token"
+# Authority = "https://login.microsoftonline.com/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/"

--- a/get_token.py
+++ b/get_token.py
@@ -12,7 +12,7 @@ redirect_uri = "http://localhost:8745/"
 
 # We use the cache to extract the refresh token
 cache = SerializableTokenCache()
-app = ConfidentialClientApplication(config.ClientId, client_credential=config.ClientSecret, token_cache=cache)
+app = ConfidentialClientApplication(config.ClientId, client_credential=config.ClientSecret, token_cache=cache, authority=config.Authority)
 
 url = app.get_authorization_request_url(config.Scopes, redirect_uri=redirect_uri)
 

--- a/refresh_token.py
+++ b/refresh_token.py
@@ -6,7 +6,7 @@ print_access_token = True
 
 # We use the cache to extract the refresh token
 cache = SerializableTokenCache()
-app = ConfidentialClientApplication(config.ClientId, client_credential=config.ClientSecret, token_cache=cache)
+app = ConfidentialClientApplication(config.ClientId, client_credential=config.ClientSecret, token_cache=cache, authority=config.Authority)
 
 
 old_refresh_token = open(config.RefreshTokenFileName,'r').read()


### PR DESCRIPTION
When attempting to get a token, M365 returned the following message:

> Message: AADSTS50194: Application [my application registration] is not configured as a multi-tenant application. Usage of the /common endpoint is not supported for such applications created after '[date]'. Use a tenant-specific endpoint or configure the application to be multi-tenant.

This pull request includes changes to pass through tenant ID for M365 configurations that do not allow multi-tenant authentication.